### PR TITLE
Misc enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,16 @@ for a product/component
 
 # tell bzxmltophill the base URL of the Bugzilla instance, so that it can link back to the original issues.
 
-  $ ./bzxmltophill bugs.xml --base-url https://jira.example.org/browse > tasks.json
+  $ ./bzxmltophill bugs.xml
 
 # ta-dah! fill Maniphest with useless chatter and let's go shopping
-  $ phill tasks.json -v 2
+  $ phill bugs.json -v 2
 
 
 # In one line:
   $ ./bzuserstophab bugs.xml /srv/http/phabricator/scripts/user/add_user.php phab_admin_username  && \
-    ./bzxmltophill bugs.xml > tasks.json && \
-    /srv/http/phabricator/scripts/phill/phill.php --input tasks.json -v 2
+    ./bzxmltophill bugs.xml && \
+    /srv/http/phabricator/scripts/phill/phill.php --input bugs.json -v 2
 
 
 ```

--- a/bzxmltophill
+++ b/bzxmltophill
@@ -3,10 +3,9 @@
 """Converts Bugzilla XML files to something Phabricator's Phill may like.
 
 Usage:
-  bzxmltophill <bz.xml> <outfile> [--base-url=url --od=utfiles_dir]
+  bzxmltophill <bz.xml> <outfile> [--od=utfiles_dir]
 
 Options:
-  --base-url=url    The default base URL for projects and tasks
   --od=outfiles_dir Where to put generated/downloaded files
   -h --help         Show this screen.
   --version         Show version.
@@ -18,9 +17,6 @@ import xml.etree.ElementTree as ET
 import json
 import os
 import re
-import base64
-
-DEFAULT_SERVER = 'https://bugzilla.gnome.org'
 
 try:
     from config import project_ids
@@ -37,11 +33,6 @@ class Converter:
         self.root = None
         self.projects = []
         self.tasks = []
-        self.base_url = DEFAULT_SERVER
-
-    def set_base_url(self, url):
-        if url:
-            self.base_url = url
 
     def url(self, i):
         return self.base_url + "/show_bug.cgi?id=" + i.findtext("bug_id")
@@ -53,6 +44,7 @@ class Converter:
             pass
 
         self.root = ET.parse(filename).getroot()
+        self.base_url = self.root.get("urlbase")
 
     def convert(self):
         self.projects_convert()
@@ -201,25 +193,8 @@ class Converter:
         return None
 
     def get_attachement(self, attachment):
-        output = "attachements/%s-%s" % (attachment.findtext("attachid"), attachment.findtext("filename"))
-        if os.path.exists(output):
-            return output
-
-        data = attachment.findtext("data")
-        if data:
-            data = base64.b64decode(data)
-            open(output, "wb").write(data)
-
-            return output
-
-        return self.download_attachement(attachment)
-
-    def download_attachement(self, attachment):
-        output = "attachements/%s-%s" % (attachment.findtext("attachid"), attachment.findtext("filename"))
-        os.system("wget '%s/attachment.cgi?id=%s' -O '%s'"
-                  % (self.base_url, attachment.findtext("attachid"), output))
-
-        return output
+        attachid = attachment.findtext("attachid")
+        return "attachement/attach.%s.dat" % attachid
 
     def convert_transactions(self, bug):
         transactions = []
@@ -310,8 +285,6 @@ def main(arguments):
         pass
 
     converter = Converter()
-    if '--base-url' in arguments:
-        converter.set_base_url(arguments['--base-url'])
 
     converter.load(filename)
     data = converter.convert()

--- a/bzxmltophill
+++ b/bzxmltophill
@@ -3,13 +3,13 @@
 """Converts Bugzilla XML files to something Phabricator's Phill may like.
 
 Usage:
-  bzxmltophill <bz.xml> <outfile> [--base-url=url -od]
+  bzxmltophill <bz.xml> <outfile> [--base-url=url --od=utfiles_dir]
 
 Options:
-  --base-url=url  The default base URL for projects and tasks
-  -od=outfiles_dir Were to put generated/downloaded files
-  -h --help       Show this screen.
-  --version       Show version.
+  --base-url=url    The default base URL for projects and tasks
+  --od=outfiles_dir Where to put generated/downloaded files
+  -h --help         Show this screen.
+  --version         Show version.
 """
 
 from docopt import docopt

--- a/bzxmltophill
+++ b/bzxmltophill
@@ -3,10 +3,9 @@
 """Converts Bugzilla XML files to something Phabricator's Phill may like.
 
 Usage:
-  bzxmltophill <bz.xml> <outfile> [--od=utfiles_dir]
+  bzxmltophill <data>
 
 Options:
-  --od=outfiles_dir Where to put generated/downloaded files
   -h --help         Show this screen.
   --version         Show version.
 """
@@ -17,6 +16,7 @@ import xml.etree.ElementTree as ET
 import json
 import os
 import re
+import glob
 
 try:
     from config import project_ids
@@ -31,27 +31,20 @@ except:
 class Converter:
     def __init__(self):
         self.root = None
-        self.projects = []
-        self.tasks = []
 
     def url(self, i):
         return self.base_url + "/show_bug.cgi?id=" + i.findtext("bug_id")
 
     def load(self, filename):
-        try:
-            os.mkdir("attachements/")
-        except FileExistsError:
-            pass
-
         self.root = ET.parse(filename).getroot()
         self.base_url = self.root.get("urlbase")
 
     def convert(self):
-        self.projects_convert()
-        self.issues_convert()
+        projects = self.projects_convert()
+        tasks = self.issues_convert()
         r = {
-            'projects': self.projects,
-            'tasks': self.tasks
+            'projects': projects,
+            'tasks': tasks
         }
         return r
 
@@ -104,6 +97,7 @@ class Converter:
                                                   project_name,
                                                   bug)
                     all_projects[project_id] = project
+        return [p for _, p in sorted(all_projects.items())]
 
     def create_project(self, pid, name, bug):
         ret = {
@@ -124,7 +118,6 @@ class Converter:
                 members.append(member.text)
 
         ret['members'] = list(set(members))
-        self.projects.append(ret)
         return ret
 
     def transaction_create(self, actor, date, kind, value=None, comment=None):
@@ -140,8 +133,8 @@ class Converter:
         return ret
 
     def issues_convert(self):
-        for bug in self.root.findall("bug"):
-            self.issue_convert(bug)
+        tasks = [self.issue_convert(bug) for bug in self.root.findall("bug")]
+        return tasks
 
     def priority_parse(self, status):
         m = {
@@ -266,24 +259,24 @@ class Converter:
             'description': i.find("long_desc").findtext("thetext"),
             'transactions': self.convert_transactions(i)
         }
-        self.tasks.append(ret)
+        return ret
 
 
 def main(arguments):
-    filename = arguments['<bz.xml>']
-    outfiles_dir = arguments.get('-od', "outfiles")
-
-    try:
-        os.mkdir(outfiles_dir)
-    except FileExistsError:
-        pass
+    data = arguments.get("<data>")
+    if os.path.isdir(data):
+        filenames = glob.glob(os.path.join(data, "bugs.*.xml"))
+    else:
+        filenames = [data]
 
     converter = Converter()
 
-    converter.load(filename)
-    data = converter.convert()
+    for filename in filenames:
+        converter.load(filename)
+        data = converter.convert()
 
-    open(arguments["<outfile>"], 'w').write(json.dumps(data, sort_keys=True, indent=4))
+        with open(os.path.splitext(filename)[0]+".json", "w") as f:
+            json.dump(data, f, sort_keys=True, indent=4)
 
 if __name__ == '__main__':
     arguments = docopt(__doc__, version='bztophill 0.1')

--- a/bzxmltophill
+++ b/bzxmltophill
@@ -30,7 +30,7 @@ except:
 try:
     from config import project_names
 except:
-    project_ids = {}
+    project_names = {}
 
 class Converter:
     def __init__(self):

--- a/bzxmltophill
+++ b/bzxmltophill
@@ -142,12 +142,6 @@ class Converter:
     def issues_convert(self):
         for bug in self.root.findall("bug"):
             self.issue_convert(bug)
-        if len(self.tasks) == 10000:
-            print("Exactly 10 000 tasks, *most* probably due to reaching"
-                  " the hard limit of XML downloading from the bugzilla"
-                  " server -- you should download the database in smaller"
-                  " pieces")
-            exit(1)
 
     def priority_parse(self, status):
         m = {

--- a/downloadbzbugs
+++ b/downloadbzbugs
@@ -29,8 +29,6 @@ try:
 except ImportError:
     from pysqlite2 import dbapi2 as sqlite
 
-DEFAULT_SERVER = 'https://bugzilla.gnome.org'
-
 # All cookie retrieval related code was taken from git-bz: http://git.fishsoup.net/cgit/git-bz/
 class CookieError(Exception):
     pass
@@ -190,10 +188,7 @@ browsers = {'firefox3': get_bugzilla_cookies_ff3,
 def browser_list():
     return ", ".join(sorted(browsers.keys()))
 
-def get_bugzilla_cookies(host, browser=None):
-    if not browser:
-        browser = "firefox3"
-
+def get_bugzilla_cookies(host, browser):
     if browser in browsers:
         do_get_cookies = browsers[browser]
     else:
@@ -263,7 +258,7 @@ def main(arguments):
     except FileExistsError:
         pass
 
-    url = arguments.get('--base-url', DEFAULT_SERVER)
+    url = arguments.get('--base-url')
     cookies = get_bugzilla_cookies(urlparse(url).netloc, arguments.get("--browser"))
     return download_xml(url, cookies, product, component,
                         arguments.get('<outfile>'), outfiles_dir)

--- a/downloadbzbugs
+++ b/downloadbzbugs
@@ -24,6 +24,7 @@ from docopt import docopt
 from configparser import RawConfigParser
 import xml.etree.ElementTree as ET
 import requests
+import tempfile
 
 try:
     from sqlite3 import dbapi2 as sqlite
@@ -230,8 +231,9 @@ def download_xml(base_url, cookies, product, component, outfile, outfiles_dir):
     rdf_path = os.path.join(outfiles_dir, "%s.rdf" % fname)
 
     r = requests.get(base_url + "/buglist.cgi", params=params, cookies=cookies, stream=True)
-    with open(rdf_path, "w") as f:
+    with tempfile.NamedTemporaryFile("w", dir=outdir) as f:
         response_stream_to_file(r, f, decode_unicode=True)
+        os.link(f.name, rdf_path)
 
     rdf_root = ET.parse(rdf_path).getroot()
 
@@ -247,8 +249,9 @@ def download_xml(base_url, cookies, product, component, outfile, outfiles_dir):
             data={"ctype": "xml", "id": bug_ids},
             stream=True
         )
-    with open(outfile, "w") as f:
+    with tempfile.NamedTemporaryFile("w", dir=outdir) as f:
         response_stream_to_file(r, f, decode_unicode=True)
+        os.link(f.name, outfile)
 
 def main(arguments):
     product_component = arguments["<product/component>"].split("/")

--- a/downloadbzbugs
+++ b/downloadbzbugs
@@ -238,9 +238,9 @@ def download_xml(base_url, cookies, product, component, outfile, outfiles_dir):
 
     # Use curl to make a simple POST query on the bugzilla server
     cookie_str = "-H 'Cookie: Bugzilla_login=%(Bugzilla_login)s; Bugzilla_logincookie=%(Bugzilla_logincookie)s;' " % cookies
-    curl_command = "curl 'https://bugzilla.gnome.org/show_bug.cgi' --compressed %s " \
+    curl_command = "curl '%s/show_bug.cgi' --compressed %s " \
         "-H 'Connection: keep-alive' " \
-        "--data 'ctype=xml&id=%s' > '%s'" % (cookie_str, '&id='.join(bug_ids), outfile)
+        "--data 'ctype=xml&id=%s' > '%s'" % (base_url, cookie_str, '&id='.join(bug_ids), outfile)
 
     if os.system(curl_command) == 0:
         return True

--- a/downloadbzbugs
+++ b/downloadbzbugs
@@ -202,8 +202,10 @@ def get_bugzilla_cookies(host, browser=None):
     try:
         return do_get_cookies(host)
     except CookieError as e:
-        die("""Error %s getting login cookie from browser: Configured browser: %s Possible browsers: %s""" %
-            (str(e), browser, browser_list()))
+        die("""Error getting login cookie from browser: %s
+Configured browser: %s
+Possible browsers: %s""" %
+            (e, browser, browser_list()))
 
 def download_xml(base_url, cookies, product, component, outfile, outfiles_dir):
     # Not that we do not use the 'standard' xmlrpc protocol as the

--- a/downloadbzbugs
+++ b/downloadbzbugs
@@ -3,14 +3,14 @@
 """Download backup XML from bugzilla
 
 Usage:
-  downloadbzbugs <product/component> <outfile> [--browser=browser -od]
+  downloadbzbugs <product/component> <outfile> [--browser=BROWSER --od=OUTFILES_DIR]
 
 Options:
-  --browser=browser Name of the browser where to find cookie to connect to bugzilla (default: firefox3)
-  -od=outfiles_dir  Were to put generated/downloaded files
+  --browser=BROWSER  Name of the browser where to find cookie to connect to bugzilla [default: firefox3].
+  --od=OUTFILES_DIR  Where to put generated/downloaded files.
 
-  -h --help       Show this screen.
-  --version       Show version.
+  -h --help          Show this screen.
+  --version          Show version.
 """
 import os
 import re
@@ -260,7 +260,7 @@ def main(arguments):
         assert("Could not find a product/component information from %s"
                % arguments["<product/component>"])
 
-    outfiles_dir = arguments.get('-od', "outfiles")
+    outfiles_dir = arguments.get('--od', "outfiles")
     try:
         os.mkdir(outfiles_dir)
     except FileExistsError:

--- a/downloadbzbugs
+++ b/downloadbzbugs
@@ -25,6 +25,7 @@ import xml.etree.ElementTree as ET
 import csv
 import requests
 import tempfile
+import glob
 
 try:
     from sqlite3 import dbapi2 as sqlite
@@ -220,9 +221,9 @@ class Downloader:
         self.outdir = outdir
 
     def setup(self):
-        os.makedirs(self.outdir)
+        os.makedirs(self.outdir, exist_ok=True)
         self.attachmentsdir = os.path.join(self.outdir, "attachments")
-        os.makedirs(self.attachmentsdir)
+        os.makedirs(self.attachmentsdir, exist_ok=True)
 
     def bug_list(self, product, component):
         params = { "offset": 0, "product": product, "ctype": "csv" }
@@ -247,8 +248,15 @@ class Downloader:
         bug_ids.sort()
         return bug_ids
 
+    def bug_skip(self):
+        bug_ids = []
+        for bugsfile in glob.iglob(os.path.join(self.outdir, "bugs.*.xml")):
+            root = ET.parse(bugsfile).getroot()
+            bug_ids += (b.text for b in root.findall("bug/bug_id"))
+        return bug_ids
+
     def bug_fetch(self, bug_ids):
-        bugsfiles = []
+        bugsfiles = glob.glob(os.path.join(self.outdir, "bugs.*.xml"))
         batch = 1000
         for offset in range(0, len(bug_ids), batch):
             ids = bug_ids[offset:offset+batch]
@@ -274,6 +282,10 @@ class Downloader:
             root = ET.parse(bugsfile).getroot()
             attach_ids += (a.findtext("attachid") for a in root.findall("*/attachment") if a.find("data") is None)
         return attach_ids
+
+    def attachment_skip(self):
+        ids = [os.path.basename(f).lstrip('attach.').rstrip('.dat') for f in glob.iglob(os.path.join(self.attachmentsdir, "attach.*.dat"))]
+        return ids
 
     def attachment_fetch(self, attach_ids):
         attachfiles = []
@@ -303,8 +315,12 @@ def main(arguments):
     downloader = Downloader(url, cookies, arguments.get('<outdir>'))
     downloader.setup()
     bug_ids = downloader.bug_list(product, component)
+    bug_skip = downloader.bug_skip()
+    bug_ids = list(sorted(set(bug_ids) - set(bug_skip)))
     bugsfiles = downloader.bug_fetch(bug_ids)
     attach_ids = downloader.attachment_list(bugsfiles)
+    attach_skip = downloader.attachment_skip()
+    attach_ids = list(sorted(set(attach_ids) - set(attach_skip)))
     downloader.attachment_fetch(attach_ids)
 
 if __name__ == '__main__':

--- a/downloadbzbugs
+++ b/downloadbzbugs
@@ -3,12 +3,11 @@
 """Download backup XML from bugzilla
 
 Usage:
-  downloadbzbugs <product/component> <outfile> [--browser=BROWSER --od=OUTFILES_DIR --base-url=URL]
+  downloadbzbugs <product/component> <outdir> [--browser=BROWSER --base-url=URL]
 
 Options:
   --base-url=URL     Base URL of the Bugzilla instance [default: https://bugzilla.gnome.org].
   --browser=BROWSER  Name of the browser where to find cookie to connect to bugzilla [default: firefox3].
-  --od=OUTFILES_DIR  Where to put generated/downloaded files.
 
   -h --help          Show this screen.
   --version          Show version.
@@ -213,7 +212,7 @@ def response_stream_to_file(r, f, decode_unicode=False):
         f.write(chunk)
     print()
 
-def download_xml(base_url, cookies, product, component, outfile, outfiles_dir):
+def download_xml(base_url, cookies, product, component, outdir):
     # Not that we do not use the 'standard' xmlrpc protocol as the
     # generated XML is more complex to parse.
     # And we do not use python-bugzilla to avoid making thousands
@@ -228,7 +227,9 @@ def download_xml(base_url, cookies, product, component, outfile, outfiles_dir):
     else:
         fname = re.compile('[^a-zA-Z]').sub("", product)
 
-    rdf_path = os.path.join(outfiles_dir, "%s.rdf" % fname)
+    rdf_path = os.path.join(outdir, "%s.rdf" % fname)
+
+    os.makedirs(outdir)
 
     r = requests.get(base_url + "/buglist.cgi", params=params, cookies=cookies, stream=True)
     with tempfile.NamedTemporaryFile("w", dir=outdir) as f:
@@ -251,7 +252,8 @@ def download_xml(base_url, cookies, product, component, outfile, outfiles_dir):
         )
     with tempfile.NamedTemporaryFile("w", dir=outdir) as f:
         response_stream_to_file(r, f, decode_unicode=True)
-        os.link(f.name, outfile)
+        bugsfile = os.path.join(outdir, "bugs.xml")
+        os.link(f.name, bugsfile)
 
 def main(arguments):
     product_component = arguments["<product/component>"].split("/")
@@ -259,16 +261,9 @@ def main(arguments):
     product = product_component[0]
     component = product_component[1] if len(product_component) > 1 else None
 
-    outfiles_dir = arguments.get('--od', "outfiles")
-    try:
-        os.mkdir(outfiles_dir)
-    except FileExistsError:
-        pass
-
     url = arguments.get('--base-url')
     cookies = get_bugzilla_cookies(urlparse(url).netloc, arguments.get("--browser"))
-    return download_xml(url, cookies, product, component,
-                        arguments.get('<outfile>'), outfiles_dir)
+    return download_xml(url, cookies, product, component, arguments.get('<outdir>'))
 
 
 if __name__ == '__main__':

--- a/downloadbzbugs
+++ b/downloadbzbugs
@@ -219,35 +219,58 @@ def download_xml(base_url, cookies, product, component, outdir):
     # And we do not use python-bugzilla to avoid making thousands
     # of queries on the server which would take much longer
 
-    params = { "limit": 0, "product": product, "ctype": "csv" }
+    params = { "offset": 0, "product": product, "ctype": "csv" }
     if component:
         params["component"] = component
 
     os.makedirs(outdir)
 
-    r = requests.get(base_url + "/buglist.cgi", params=params, cookies=cookies)
+    bug_ids = []
+    while True:
+        # we can't be sure that we got all the bugs or we just hit the rows
+        # limit configured for the current bugzilla instance, so try again
+        # until we get an empty list
+        print("listing bugs at offset", params['offset'])
+        print(base_url + "/buglist.cgi")
+        r = requests.get(base_url + "/buglist.cgi", params=params, cookies=cookies)
 
-    reader = csv.DictReader(r.text.splitlines())
-    bug_ids = [row["bug_id"] for row in reader]
+        reader = csv.DictReader(r.text.splitlines())
+        ids = [row["bug_id"] for row in reader]
+        if not ids:
+            break
+        bug_ids += ids
+        params["offset"] += len(ids)
     bug_ids.sort()
 
-    r = requests.post(base_url + "/show_bug.cgi",
-            cookies=cookies,
-            data={"ctype": "xml", "id": bug_ids},
-            stream=True
-        )
-    bugsfile = os.path.join(outdir, "bugs.xml")
-    with tempfile.NamedTemporaryFile("w", dir=outdir) as f:
-        response_stream_to_file(r, f, decode_unicode=True)
-        os.link(f.name, bugsfile)
+    bugsfiles = []
+    batch = 1000
+    for offset in range(0, len(bug_ids), batch):
+        ids = bug_ids[offset:offset+batch]
+        print("fetching", len(ids), "bugs at offset", offset, "of", len(bug_ids))
+        print(base_url + "/show_bug.cgi")
+
+        r = requests.post(base_url + "/show_bug.cgi",
+                cookies=cookies,
+                data={"ctype": "xml", "id": ids},
+                stream=True
+            )
+        idx = len(bugsfiles) + 1
+        with tempfile.NamedTemporaryFile("w", dir=outdir) as f:
+            response_stream_to_file(r, f, decode_unicode=True)
+            bugsfile = os.path.join(outdir, "bugs.%04d.xml" % idx)
+            os.link(f.name, bugsfile)
+            bugsfiles.append(bugsfile)
+
+    attach_ids = []
+    for bugsfile in bugsfiles:
+        root = ET.parse(bugsfile).getroot()
+        attach_ids += (a.findtext("attachid") for a in root.findall("*/attachment") if a.find("data") is None)
 
     attachmentsdir = os.path.join(outdir, "attachments")
     os.makedirs(attachmentsdir)
-    root = ET.parse(bugsfile).getroot()
-    for attachment in root.findall("*/attachment"):
-        if attachment.find("data") is not None:
-            continue
-        attachid = attachment.findtext("attachid")
+    for count, attachid in enumerate(attach_ids):
+        print("fetching attachment", count, "of", len(attach_ids))
+        print(base_url + "/attachment.cgi")
         r = requests.get(base_url + "/attachment.cgi",
                 params={"id": attachid},
                 cookies=cookies,

--- a/downloadbzbugs
+++ b/downloadbzbugs
@@ -266,11 +266,6 @@ def main(arguments):
     except FileExistsError:
         pass
 
-    try:
-        os.mkdir(outfiles_dir)
-    except FileExistsError:
-        pass
-
     url = arguments.get('--base-url', DEFAULT_SERVER)
     cookies = get_bugzilla_cookies(urlparse(url).netloc, arguments.get("--browser"))
     return download_xml(url, cookies, product, component,

--- a/downloadbzbugs
+++ b/downloadbzbugs
@@ -213,71 +213,83 @@ def response_stream_to_file(r, f, decode_unicode=False):
         f.write(chunk)
     print()
 
-def download_xml(base_url, cookies, product, component, outdir):
-    # Not that we do not use the 'standard' xmlrpc protocol as the
-    # generated XML is more complex to parse.
-    # And we do not use python-bugzilla to avoid making thousands
-    # of queries on the server which would take much longer
+class Downloader:
+    def __init__(self, base_url, cookies, outdir):
+        self.base_url = base_url
+        self.cookies = cookies
+        self.outdir = outdir
 
-    params = { "offset": 0, "product": product, "ctype": "csv" }
-    if component:
-        params["component"] = component
+    def setup(self):
+        os.makedirs(self.outdir)
+        self.attachmentsdir = os.path.join(self.outdir, "attachments")
+        os.makedirs(self.attachmentsdir)
 
-    os.makedirs(outdir)
+    def bug_list(self, product, component):
+        params = { "offset": 0, "product": product, "ctype": "csv" }
+        if component:
+            params["component"] = component
 
-    bug_ids = []
-    while True:
-        # we can't be sure that we got all the bugs or we just hit the rows
-        # limit configured for the current bugzilla instance, so try again
-        # until we get an empty list
-        print("listing bugs at offset", params['offset'])
-        print(base_url + "/buglist.cgi")
-        r = requests.get(base_url + "/buglist.cgi", params=params, cookies=cookies)
+        bug_ids = []
+        while True:
+            # we can't be sure that we got all the bugs or we just hit the rows
+            # limit configured for the current bugzilla instance, so try again
+            # until we get an empty list
+            print("listing bugs at offset", params['offset'])
+            print(self.base_url + "/buglist.cgi")
+            r = requests.get(self.base_url + "/buglist.cgi", params=params, cookies=self.cookies)
 
-        reader = csv.DictReader(r.text.splitlines())
-        ids = [row["bug_id"] for row in reader]
-        if not ids:
-            break
-        bug_ids += ids
-        params["offset"] += len(ids)
-    bug_ids.sort()
+            reader = csv.DictReader(r.text.splitlines())
+            ids = [row["bug_id"] for row in reader]
+            if not ids:
+                break
+            bug_ids += ids
+            params["offset"] += len(ids)
+        bug_ids.sort()
+        return bug_ids
 
-    bugsfiles = []
-    batch = 1000
-    for offset in range(0, len(bug_ids), batch):
-        ids = bug_ids[offset:offset+batch]
-        print("fetching", len(ids), "bugs at offset", offset, "of", len(bug_ids))
-        print(base_url + "/show_bug.cgi")
+    def bug_fetch(self, bug_ids):
+        bugsfiles = []
+        batch = 1000
+        for offset in range(0, len(bug_ids), batch):
+            ids = bug_ids[offset:offset+batch]
+            print("fetching", len(ids), "bugs at offset", offset, "of", len(bug_ids))
+            print(self.base_url + "/show_bug.cgi")
 
-        r = requests.post(base_url + "/show_bug.cgi",
-                cookies=cookies,
-                data={"ctype": "xml", "id": ids},
-                stream=True
-            )
-        idx = len(bugsfiles) + 1
-        with tempfile.NamedTemporaryFile("w", dir=outdir) as f:
-            response_stream_to_file(r, f, decode_unicode=True)
-            bugsfile = os.path.join(outdir, "bugs.%04d.xml" % idx)
-            os.link(f.name, bugsfile)
-            bugsfiles.append(bugsfile)
+            r = requests.post(self.base_url + "/show_bug.cgi",
+                    cookies=self.cookies,
+                    data={"ctype": "xml", "id": ids},
+                    stream=True
+                )
+            idx = len(bugsfiles) + 1
+            with tempfile.NamedTemporaryFile("w", dir=self.outdir) as f:
+                response_stream_to_file(r, f, decode_unicode=True)
+                bugsfile = os.path.join(self.outdir, "bugs.%04d.xml" % idx)
+                os.link(f.name, bugsfile)
+                bugsfiles.append(bugsfile)
+        return bugsfiles
 
-    attach_ids = []
-    for bugsfile in bugsfiles:
-        root = ET.parse(bugsfile).getroot()
-        attach_ids += (a.findtext("attachid") for a in root.findall("*/attachment") if a.find("data") is None)
+    def attachment_list(self, bugsfiles):
+        attach_ids = []
+        for bugsfile in bugsfiles:
+            root = ET.parse(bugsfile).getroot()
+            attach_ids += (a.findtext("attachid") for a in root.findall("*/attachment") if a.find("data") is None)
+        return attach_ids
 
-    attachmentsdir = os.path.join(outdir, "attachments")
-    os.makedirs(attachmentsdir)
-    for count, attachid in enumerate(attach_ids):
-        print("fetching attachment", count, "of", len(attach_ids))
-        print(base_url + "/attachment.cgi")
-        r = requests.get(base_url + "/attachment.cgi",
-                params={"id": attachid},
-                cookies=cookies,
-                stream=True)
-        with tempfile.NamedTemporaryFile("wb", dir=attachmentsdir) as f:
-            response_stream_to_file(r, f)
-            os.link(f.name, os.path.join(attachmentsdir, "attach.%s.dat" % attachid))
+    def attachment_fetch(self, attach_ids):
+        attachfiles = []
+        for count, attachid in enumerate(attach_ids):
+            print("fetching attachment", count, "of", len(attach_ids))
+            print(self.base_url + "/attachment.cgi")
+            r = requests.get(self.base_url + "/attachment.cgi",
+                    params={"id": attachid},
+                    cookies=self.cookies,
+                    stream=True)
+            with tempfile.NamedTemporaryFile("wb", dir=self.attachmentsdir) as f:
+                response_stream_to_file(r, f)
+                attachfile = os.path.join(self.attachmentsdir, "attach.%s.dat" % attachid)
+                os.link(f.name, attachfile)
+                attachfiles.append(attachfile)
+        return attachfiles
 
 def main(arguments):
     product_component = arguments["<product/component>"].split("/")
@@ -287,8 +299,13 @@ def main(arguments):
 
     url = arguments.get('--base-url')
     cookies = get_bugzilla_cookies(urlparse(url).netloc, arguments.get("--browser"))
-    return download_xml(url, cookies, product, component, arguments.get('<outdir>'))
 
+    downloader = Downloader(url, cookies, arguments.get('<outdir>'))
+    downloader.setup()
+    bug_ids = downloader.bug_list(product, component)
+    bugsfiles = downloader.bug_fetch(bug_ids)
+    attach_ids = downloader.attachment_list(bugsfiles)
+    downloader.attachment_fetch(attach_ids)
 
 if __name__ == '__main__':
     arguments = docopt(__doc__, version='downloadbzbugs 0.1')

--- a/downloadbzbugs
+++ b/downloadbzbugs
@@ -22,6 +22,7 @@ from urllib.parse import urlparse
 from docopt import docopt
 from configparser import RawConfigParser
 import xml.etree.ElementTree as ET
+import csv
 import requests
 import tempfile
 
@@ -218,32 +219,17 @@ def download_xml(base_url, cookies, product, component, outdir):
     # And we do not use python-bugzilla to avoid making thousands
     # of queries on the server which would take much longer
 
-    params = { "limit": 0, "product": product, "ctype": "rdf" }
+    params = { "limit": 0, "product": product, "ctype": "csv" }
     if component:
         params["component"] = component
 
-    if component:
-        fname = re.compile('[^a-zA-Z]').sub("", product + component)
-    else:
-        fname = re.compile('[^a-zA-Z]').sub("", product)
-
-    rdf_path = os.path.join(outdir, "%s.rdf" % fname)
-
     os.makedirs(outdir)
 
-    r = requests.get(base_url + "/buglist.cgi", params=params, cookies=cookies, stream=True)
-    with tempfile.NamedTemporaryFile("w", dir=outdir) as f:
-        response_stream_to_file(r, f, decode_unicode=True)
-        os.link(f.name, rdf_path)
+    r = requests.get(base_url + "/buglist.cgi", params=params, cookies=cookies)
 
-    rdf_root = ET.parse(rdf_path).getroot()
-
-    # Work around ElementTree not able to handle namespaces properly
-    bug_ids_path = "bz:result/bz:bugs/r:Seq/r:li/bz:bug/bz:id".replace(
-        "bz:", "{http://www.bugzilla.org/rdf#}").replace(
-        "r:", "{http://www.w3.org/1999/02/22-rdf-syntax-ns#}")
-
-    bug_ids = [bugid.text for bugid in rdf_root.findall(bug_ids_path)]
+    reader = csv.DictReader(r.text.splitlines())
+    bug_ids = [row["bug_id"] for row in reader]
+    bug_ids.sort()
 
     r = requests.post(base_url + "/show_bug.cgi",
             cookies=cookies,

--- a/downloadbzbugs
+++ b/downloadbzbugs
@@ -3,7 +3,7 @@
 """Download backup XML from bugzilla
 
 Usage:
-  downloadbugs <product/component> <outfile> [--browser=browser -od]
+  downloadbzbugs <product/component> <outfile> [--browser=browser -od]
 
 Options:
   --browser=browser Name of the browser where to find cookie to connect to bugzilla (default: firefox3)
@@ -273,5 +273,5 @@ def main(arguments):
 
 
 if __name__ == '__main__':
-    arguments = docopt(__doc__, version='bztophill 0.1')
+    arguments = docopt(__doc__, version='downloadbzbugs 0.1')
     main(arguments)

--- a/downloadbzbugs
+++ b/downloadbzbugs
@@ -3,9 +3,10 @@
 """Download backup XML from bugzilla
 
 Usage:
-  downloadbzbugs <product/component> <outfile> [--browser=BROWSER --od=OUTFILES_DIR]
+  downloadbzbugs <product/component> <outfile> [--browser=BROWSER --od=OUTFILES_DIR --base-url=URL]
 
 Options:
+  --base-url=URL     Base URL of the Bugzilla instance [default: https://bugzilla.gnome.org].
   --browser=BROWSER  Name of the browser where to find cookie to connect to bugzilla [default: firefox3].
   --od=OUTFILES_DIR  Where to put generated/downloaded files.
 

--- a/downloadbzbugs
+++ b/downloadbzbugs
@@ -23,6 +23,7 @@ from urllib.parse import urlparse
 from docopt import docopt
 from configparser import RawConfigParser
 import xml.etree.ElementTree as ET
+import requests
 
 try:
     from sqlite3 import dbapi2 as sqlite
@@ -202,15 +203,24 @@ Configured browser: %s
 Possible browsers: %s""" %
             (e, browser, browser_list()))
 
+def response_stream_to_file(r, f, decode_unicode=False):
+    total = 0
+    print(r.url, end="", flush=True)
+    for chunk in r.iter_content(chunk_size=1024, decode_unicode=decode_unicode):
+        total += len(chunk)
+        print("\r\033[K", r.url, " downloaded ", total, " bytes", sep="", end="", flush=True)
+        f.write(chunk)
+    print()
+
 def download_xml(base_url, cookies, product, component, outfile, outfiles_dir):
     # Not that we do not use the 'standard' xmlrpc protocol as the
     # generated XML is more complex to parse.
     # And we do not use python-bugzilla to avoid making thousands
     # of queries on the server which would take much longer
 
-    query_url = "%s/buglist.cgi?limit=0&product=%s&ctype=rdf" % (base_url, product)
+    params = { "limit": 0, "product": product, "ctype": "rdf" }
     if component:
-        query_url += "&component=%s" % component
+        params["component"] = component
 
     if component:
         fname = re.compile('[^a-zA-Z]').sub("", product + component)
@@ -219,10 +229,9 @@ def download_xml(base_url, cookies, product, component, outfile, outfiles_dir):
 
     rdf_path = os.path.join(outfiles_dir, "%s.rdf" % fname)
 
-    if os.system("wget '%s' -O %s" % (query_url, rdf_path)) != 0:
-        print("ERROR: Could not get list of bugs for %s/%s" % (product, component))
-
-        return None
+    r = requests.get(base_url + "/buglist.cgi", params=params, cookies=cookies, stream=True)
+    with open(rdf_path, "w") as f:
+        response_stream_to_file(r, f, decode_unicode=True)
 
     rdf_root = ET.parse(rdf_path).getroot()
 
@@ -233,18 +242,13 @@ def download_xml(base_url, cookies, product, component, outfile, outfiles_dir):
 
     bug_ids = [bugid.text for bugid in rdf_root.findall(bug_ids_path)]
 
-    # Use curl to make a simple POST query on the bugzilla server
-    cookie_str = "-H 'Cookie: Bugzilla_login=%(Bugzilla_login)s; Bugzilla_logincookie=%(Bugzilla_logincookie)s;' " % cookies
-    curl_command = "curl '%s/show_bug.cgi' --compressed %s " \
-        "-H 'Connection: keep-alive' " \
-        "--data 'ctype=xml&id=%s' > '%s'" % (base_url, cookie_str, '&id='.join(bug_ids), outfile)
-
-    if os.system(curl_command) == 0:
-        return True
-    else:
-        print("ERROR: Could not get XML for %s/%s" % (product, component))
-        return False
-
+    r = requests.post(base_url + "/show_bug.cgi",
+            cookies=cookies,
+            data={"ctype": "xml", "id": bug_ids},
+            stream=True
+        )
+    with open(outfile, "w") as f:
+        response_stream_to_file(r, f, decode_unicode=True)
 
 def main(arguments):
     product_component = arguments["<product/component>"].split("/")

--- a/downloadbzbugs
+++ b/downloadbzbugs
@@ -253,13 +253,7 @@ def main(arguments):
     product_component = arguments["<product/component>"].split("/")
 
     product = product_component[0]
-    if len(product_component) == 2:
-        component = product_component[1]
-    elif len(product_component) == 1:
-        component = None
-    else:
-        assert("Could not find a product/component information from %s"
-               % arguments["<product/component>"])
+    component = product_component[1] if len(product_component) > 1 else None
 
     outfiles_dir = arguments.get('--od', "outfiles")
     try:

--- a/downloadbzbugs
+++ b/downloadbzbugs
@@ -26,6 +26,7 @@ import csv
 import requests
 import tempfile
 import glob
+import base64
 
 try:
     from sqlite3 import dbapi2 as sqlite
@@ -283,6 +284,31 @@ class Downloader:
             attach_ids += (a.findtext("attachid") for a in root.findall("*/attachment") if a.find("data") is None)
         return attach_ids
 
+    def attachment_extract(self, bugsfiles):
+        attach_ids = []
+        for bugsfile in bugsfiles:
+            et = ET.parse(bugsfile)
+            root = et.getroot()
+            attachments = [a for a in root.findall("*/attachment") if a.find("data") is not None]
+            for count, a in enumerate(attachments):
+                print("extracting attachment", count+1, "of", len(attachments), "from", bugsfile)
+                data = a.find("data")
+                assert data.get('encoding') == 'base64'
+                attachid = a.findtext("attachid")
+                attachfile = os.path.join(self.attachmentsdir, "attach.%s.dat" % attachid)
+                if os.path.exists(attachfile):
+                    continue
+                raw = base64.b64decode(data.text)
+                with tempfile.NamedTemporaryFile("wb", dir=self.attachmentsdir) as f:
+                    f.write(raw)
+                    os.link(f.name, attachfile)
+                a.remove(data)
+                attach_ids.append(attachid)
+            with tempfile.NamedTemporaryFile("wb", dir=self.outdir, delete=False) as f:
+                et.write(f, encoding='utf-8', xml_declaration=True)
+                os.replace(f.name, bugsfile)
+        return attach_ids
+
     def attachment_skip(self):
         ids = [os.path.basename(f).lstrip('attach.').rstrip('.dat') for f in glob.iglob(os.path.join(self.attachmentsdir, "attach.*.dat"))]
         return ids
@@ -319,6 +345,7 @@ def main(arguments):
     bug_ids = list(sorted(set(bug_ids) - set(bug_skip)))
     bugsfiles = downloader.bug_fetch(bug_ids)
     attach_ids = downloader.attachment_list(bugsfiles)
+    downloader.attachment_extract(bugsfiles)
     attach_skip = downloader.attachment_skip()
     attach_ids = list(sorted(set(attach_ids) - set(attach_skip)))
     downloader.attachment_fetch(attach_ids)

--- a/downloadbzbugs
+++ b/downloadbzbugs
@@ -250,10 +250,25 @@ def download_xml(base_url, cookies, product, component, outdir):
             data={"ctype": "xml", "id": bug_ids},
             stream=True
         )
+    bugsfile = os.path.join(outdir, "bugs.xml")
     with tempfile.NamedTemporaryFile("w", dir=outdir) as f:
         response_stream_to_file(r, f, decode_unicode=True)
-        bugsfile = os.path.join(outdir, "bugs.xml")
         os.link(f.name, bugsfile)
+
+    attachmentsdir = os.path.join(outdir, "attachments")
+    os.makedirs(attachmentsdir)
+    root = ET.parse(bugsfile).getroot()
+    for attachment in root.findall("*/attachment"):
+        if attachment.find("data") is not None:
+            continue
+        attachid = attachment.findtext("attachid")
+        r = requests.get(base_url + "/attachment.cgi",
+                params={"id": attachid},
+                cookies=cookies,
+                stream=True)
+        with tempfile.NamedTemporaryFile("wb", dir=attachmentsdir) as f:
+            response_stream_to_file(r, f)
+            os.link(f.name, os.path.join(attachmentsdir, "attach.%s.dat" % attachid))
 
 def main(arguments):
     product_component = arguments["<product/component>"].split("/")


### PR DESCRIPTION
- Use [python-requests](http://python-requests.org) instead of firing up `curl` and `wget`
- Removed the attachment contents download logic from `bzxmltophill` by making `downloadbzbugs` ensure they are available as files
- Work around the Bugzilla limit of 10000 result rows when retrieving the list of bugs
- Split bugs retrieval in batches to handle big projects
- Resumable downloads
- Misc fixes
